### PR TITLE
Add generating .json file by path to source-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,28 @@ module.exports = {
 };
 ```
 
-This will create a file `my-file.json` in webpack's output directory, with contents:
+Also you can generate `.json` file from source-module by path to it:
+
+```js
+// source.js
+module.exports = {
+  foo: 'bar'
+}
+
+// webpack.config.js
+const GenerateJsonPlugin = require('generate-json-webpack-plugin');
+
+module.exports = {
+  // ...
+  plugins: [
+    // ...
+    new GenerateJsonPlugin('my-file.json', __dirname + '/source.js')
+  ]
+  // ...
+};
+```
+
+All these cases will create a file `my-file.json` in webpack's output directory, with contents:
 ```json
 {"foo":"bar"}
 ```

--- a/example/__tests__/example-test.js
+++ b/example/__tests__/example-test.js
@@ -29,4 +29,28 @@ describe('example', () => {
       );
     });
   }));
+  it('creates a file my-file-from-module.json', () => new Promise((resolve, reject) => {
+    webpack(config, (error, stats) => {
+      if (error) {
+        reject(error);
+      }
+      fs.readFile(
+        path.resolve(stats.compilation.compiler.outputPath, 'my-file-from-module.json'),
+        'utf8',
+        (err, data) => {
+          if (err) {
+            reject(err);
+          }
+          expect(data).toBe(
+            '{\n' +
+            '  "foo": "baz",\n' +
+            '  "one": "two",\n' +
+            '  "module": true\n' +
+            '}'
+          );
+          resolve();
+        }
+      );
+    });
+  }));
 });

--- a/example/module.js
+++ b/example/module.js
@@ -1,0 +1,5 @@
+module.exports = {
+  foo: 'bar',
+  one: 'two',
+  module: true,
+};

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -20,5 +20,16 @@ module.exports = {
       },
       2
     ),
+    new GenerateJsonPlugin(
+      'my-file-from-module.json',
+      path.join(__dirname, 'module'),
+      (key, value) => {
+        if (value === 'bar') {
+          return 'baz';
+        }
+        return value;
+      },
+      2
+    ),
   ],
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ function GenerateJsonPlugin(filename, value, replacer, space) {
 
 GenerateJsonPlugin.prototype.apply = function apply(compiler) {
   compiler.plugin('emit', (compilation, done) => {
-    const json = JSON.stringify(this.value, this.replacer, this.space);
+    const value = typeof this.value === 'string' ? require(this.value) : this.value; // eslint-disable-line global-require
+    const json = JSON.stringify(value, this.replacer, this.space);
     compilation.assets[this.filename] = { // eslint-disable-line no-param-reassign
       source: () => json,
       size: () => json.length,


### PR DESCRIPTION
### Something like:
```javascript
// source.js
module.exports = {
  foo: 'bar'
}

// webpack.config.js
const GenerateJsonPlugin = require('generate-json-webpack-plugin');

module.exports = {
  // ...
  plugins: [
    // ...
    new GenerateJsonPlugin('my-file.json', __dirname + '/source.js')
  ]
  // ...
};
```

resolve #38 