### PR TITLE
Improve performance for Webpack watch mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,25 @@
 function GenerateJsonPlugin(filename, value, replacer, space) {
   Object.assign(this, { filename, value, replacer, space });
+
+  this.previousJson = null;
 }
 
 GenerateJsonPlugin.prototype.apply = function apply(compiler) {
   compiler.plugin('emit', (compilation, done) => {
     const json = JSON.stringify(this.value, this.replacer, this.space);
+
+    // For faster performance on watch mode
+    if (this.previousJson === json) {
+      done();
+      return;
+    }
+
     compilation.assets[this.filename] = {
       source: () => json,
       size: () => json.length,
     };
+
+    this.previousJson = json;
     done();
   });
 };


### PR DESCRIPTION
I was investigating ways to speed up my Webpack workflow and I found this potential optimisation.

Previously, the file would be re-generated on every change/emit of other files, which is unnecessary.