### PR TITLE
Remove "engines" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "roots": [
       "<rootDir>/example"
     ]
-  },
-  "engines": {
-    "node": ">=6.11.5"
   }
 }


### PR DESCRIPTION
This package is still compatible with older versions of webpack and
Node.js, so the "engines" field is not needed.

Fixes #61 